### PR TITLE
Makefile for installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+NODE_MODULES = node_modules
+
+install: $(NODE_MODULES)
+	@scripts/postinstall.sh
+
+.PHONY: install
+
+$(NODE_MODULES):
+	@npm install &> /dev/null

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "DevExp",
   "main": "app.js",
   "scripts": {
-    "postinstall": "scripts/postinstall.sh",
     "lint": "eslint . || true",
     "test": "./scripts/run mocha -r ./tests/setup.js -R spec app/**/__tests__/**/*.test.js",
     "test:only": "npm run mongo:dev | ./scripts/run mocha -w -r ./tests/setup.js -R spec app/**/__tests__/**/*.test.js",


### PR DESCRIPTION
Сейчас процесс установки через `npm install` выглядит примерно вот так:

``` bash
sbmaxx@sbmaxx-mba ~/Develop/devexp $ npm install
npm WARN package.json devexp@0.1.0 No repository field.
npm WARN peerDependencies The peer dependency babel-core@* included from babel-loader will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.

> node-stringprep@0.7.2 install /Users/sbmaxx/Develop/devexp/node_modules/node-xmpp-client/node_modules/node-xmpp-core/node_modules/node-stringprep
> node-gyp rebuild

  SOLINK_MODULE(target) Release/node_stringprep.node
npm WARN prefer global nodemon@1.4.0 should be installed with -g

> bufferutil@1.1.0 install /Users/sbmaxx/Develop/devexp/node_modules/webpack-dev-server/node_modules/socket.io/node_modules/engine.io/node_modules/ws/node_modules/bufferutil
> node-gyp rebuild

  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/bufferutil.node

> utf-8-validate@1.1.0 install /Users/sbmaxx/Develop/devexp/node_modules/webpack-dev-server/node_modules/socket.io/node_modules/engine.io/node_modules/ws/node_modules/utf-8-validate
> node-gyp rebuild

  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/validation.node

> fsevents@0.3.7 install /Users/sbmaxx/Develop/devexp/node_modules/babel/node_modules/chokidar/node_modules/fsevents
> node-gyp rebuild

  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
  SOLINK_MODULE(target) Release/fse.node

> utf-8-validate@1.1.0 install /Users/sbmaxx/Develop/devexp/node_modules/webpack-dev-server/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/node_modules/utf-8-validate
> node-gyp rebuild

  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/validation.node

> bufferutil@1.1.0 install /Users/sbmaxx/Develop/devexp/node_modules/webpack-dev-server/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/node_modules/bufferutil
> node-gyp rebuild

  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/bufferutil.node

> fsevents@0.3.7 install /Users/sbmaxx/Develop/devexp/node_modules/webpack/node_modules/watchpack/node_modules/chokidar/node_modules/fsevents
> node-gyp rebuild

  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
  SOLINK_MODULE(target) Release/fse.node
npm WARN installMany nopt was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree
npm WARN installMany npmlog was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree
npm WARN installMany request was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree
npm WARN installMany semver was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree
npm WARN installMany tar was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree
npm WARN installMany tar-pack was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree
npm WARN installMany mkdirp was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree
npm WARN installMany rc was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree
npm WARN installMany rimraf was bundled with node-pre-gyp@0.6.4, but bundled package wasn't found in unpacked tree

> kerberos@0.0.12 install /Users/sbmaxx/Develop/devexp/node_modules/mongoose/node_modules/mongodb/node_modules/mongodb-core/node_modules/kerberos
> (node-gyp rebuild 2> builderror.log) || (exit 0)

  CXX(target) Release/obj.target/kerberos/lib/kerberos.o
  CXX(target) Release/obj.target/kerberos/lib/worker.o
  CC(target) Release/obj.target/kerberos/lib/kerberosgss.o
  CC(target) Release/obj.target/kerberos/lib/base64.o
  CXX(target) Release/obj.target/kerberos/lib/kerberos_context.o
  SOLINK_MODULE(target) Release/kerberos.node

> node-sass@3.2.0 install /Users/sbmaxx/Develop/devexp/node_modules/node-sass
> node scripts/install.js

Binary downloaded and installed at /Users/sbmaxx/Develop/devexp/node_modules/node-sass/vendor/darwin-x64-14/binding.node

> bson-ext@0.1.10 install /Users/sbmaxx/Develop/devexp/node_modules/mongoose/node_modules/bson/node_modules/bson-ext
> (node-pre-gyp install --fallback-to-build) || (node-gyp rebuild 2> builderror.log) || (exit 0)

  CXX(target) Release/obj.target/bson/ext/bson.o
  SOLINK_MODULE(target) Release/bson.node

> node-sass@3.2.0 postinstall /Users/sbmaxx/Develop/devexp/node_modules/node-sass
> node scripts/build.js

` /Users/sbmaxx/Develop/devexp/node_modules/node-sass/vendor/darwin-x64-14/binding.node ` exists.
 testing binary.
Binary is fine; exiting.
\
> iconv@2.1.8 install /Users/sbmaxx/Develop/devexp/node_modules/node-xmpp-client/node_modules/node-xmpp-core/node_modules/ltx/node_modules/node-expat/node_modules/iconv
> node-gyp rebuild

  CC(target) Release/obj.target/libiconv/deps/libiconv/lib/iconv.o
  LIBTOOL-STATIC Release/iconv.a
  CXX(target) Release/obj.target/iconv/src/binding.o
  SOLINK_MODULE(target) Release/iconv.node

> node-expat@2.3.8 install /Users/sbmaxx/Develop/devexp/node_modules/node-xmpp-client/node_modules/node-xmpp-core/node_modules/ltx/node_modules/node-expat
> node-gyp rebuild

  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmlparse.o
  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmltok.o
../deps/libexpat/lib/xmltok.c:471:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:484:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:504:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:517:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:730:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:749:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:762:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:775:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:871:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
../deps/libexpat/lib/xmltok.c:890:1: warning: missing field 'isName2' initializer [-Wmissing-field-initializers]
};
^
10 warnings generated.
  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmlrole.o
  LIBTOOL-STATIC Release/libexpat.a
  CXX(target) Release/obj.target/node_expat/node-expat.o
  SOLINK_MODULE(target) Release/node_expat.node

> devexp@0.1.0 postinstall /Users/sbmaxx/Develop/devexp
> scripts/postinstall.sh


        /\_/\   == -- == -- == -- ==
   ____/ o o \  You are almost done!
 /~____  =ø= /  == -- == -- == -- ==
(______)__m_m)

!IMPORTANT! To complete setup please do following:

1) Go to app/config/github.js and fill the 'token' field with github api access token.
2) Go to app/config/github_org_team.js and setup your repo -> github org team mapping or switch
   to simple team plugin by replacing github_team_org plugin in app/config/review.js
   to simple_team and don't forget to pass team to simple_team plugin,
   example config are here — app/config/team.js.

    ________. And if something went wrong — keep calm and forget about this repo.
  ~(_]------' -=-=- OR -=-=-
 /_(          You can commit an issue here: https://github.com/devexp-org/devexp/issues
whatwg-fetch@0.9.0 node_modules/whatwg-fetch

parallelshell@1.2.0 node_modules/parallelshell

chai-as-promised@5.1.0 node_modules/chai-as-promised

terror@1.3.0 node_modules/terror

badgs@0.5.1 node_modules/badgs

response-time@2.3.1 node_modules/response-time
├── on-headers@1.0.0
└── depd@1.0.1

eslint-plugin-react@2.7.1 node_modules/eslint-plugin-react

proxyquire@1.6.0 node_modules/proxyquire
├── module-not-found-error@1.0.1
└── fill-keys@1.0.1 (merge-descriptors@1.0.0, is-object@1.0.1)

react-router@0.13.3 node_modules/react-router
├── object-assign@2.1.1
└── qs@2.4.1

react-hot-loader@1.2.8 node_modules/react-hot-loader
├── react-hot-api@0.4.5
└── source-map@0.1.40 (amdefine@1.0.0)

body-parser@1.13.3 node_modules/body-parser
├── bytes@2.1.0
├── content-type@1.0.1
├── depd@1.0.1
├── qs@4.0.0
├── http-errors@1.3.1 (inherits@2.0.1, statuses@1.2.1)
├── on-finished@2.3.0 (ee-first@1.1.1)
├── raw-body@2.1.2 (unpipe@1.0.0)
├── debug@2.2.0 (ms@0.7.1)
├── type-is@1.6.6 (media-typer@0.3.0, mime-types@2.1.4)
└── iconv-lite@0.4.11

react-timeago@2.2.1 node_modules/react-timeago

chai@3.2.0 node_modules/chai
├── assertion-error@1.0.1
├── type-detect@1.0.0
└── deep-eql@0.1.3 (type-detect@0.1.1)

express@4.13.2 node_modules/express
├── escape-html@1.0.2
├── merge-descriptors@1.0.0
├── array-flatten@1.1.1
├── cookie@0.1.3
├── utils-merge@1.0.0
├── cookie-signature@1.0.6
├── methods@1.1.1
├── fresh@0.3.0
├── range-parser@1.0.2
├── vary@1.0.1
├── path-to-regexp@0.1.7
├── etag@1.7.0
├── content-type@1.0.1
├── parseurl@1.3.0
├── content-disposition@0.5.0
├── serve-static@1.10.0
├── depd@1.0.1
├── finalhandler@0.4.0 (unpipe@1.0.0)
├── on-finished@2.3.0 (ee-first@1.1.1)
├── qs@4.0.0
├── debug@2.2.0 (ms@0.7.1)
├── proxy-addr@1.0.8 (forwarded@0.1.0, ipaddr.js@1.0.1)
├── send@0.13.0 (destroy@1.0.3, statuses@1.2.1, ms@0.7.1, mime@1.3.4, http-errors@1.3.1)
├── type-is@1.6.6 (media-typer@0.3.0, mime-types@2.1.4)
└── accepts@1.2.12 (negotiator@0.5.3, mime-types@2.1.4)

es6-promise@2.3.0 node_modules/es6-promise

winston@1.0.1 node_modules/winston
├── cycle@1.0.3
├── stack-trace@0.0.9
├── eyes@0.1.8
├── isstream@0.1.2
├── pkginfo@0.3.0
├── async@0.9.2
└── colors@1.0.3

style-loader@0.12.3 node_modules/style-loader
└── loader-utils@0.2.11 (big.js@3.1.3, json5@0.4.0)

sass-loader@1.0.3 node_modules/sass-loader
└── loader-utils@0.2.11 (big.js@3.1.3, json5@0.4.0)

extract-text-webpack-plugin@0.8.2 node_modules/extract-text-webpack-plugin
├── async@1.4.0
└── loader-utils@0.2.11 (big.js@3.1.3, json5@0.4.0)

css-loader@0.14.5 node_modules/css-loader
├── fastparse@1.1.1
├── source-list-map@0.1.5
├── loader-utils@0.2.11 (big.js@3.1.3, json5@0.4.0)
└── clean-css@3.3.7 (commander@2.8.1, source-map@0.4.4)

mocha@2.2.5 node_modules/mocha
├── escape-string-regexp@1.0.2
├── supports-color@1.2.1
├── growl@1.8.1
├── commander@2.3.0
├── diff@1.4.0
├── debug@2.0.0 (ms@0.6.2)
├── mkdirp@0.5.0 (minimist@0.0.8)
├── glob@3.2.3 (inherits@2.0.1, graceful-fs@2.0.3, minimatch@0.2.14)
└── jade@0.26.3 (commander@0.6.1, mkdirp@0.3.0)

github@0.2.4 node_modules/github
└── mime@1.3.4

nodemon@1.4.0 node_modules/nodemon
├── touch@0.0.4 (nopt@1.0.10)
├── minimatch@0.3.0 (sigmund@1.0.1, lru-cache@2.6.5)
├── ps-tree@0.0.3 (event-stream@0.5.3)
└── update-notifier@0.3.2 (is-npm@1.0.0, string-length@1.0.1, chalk@1.1.0, semver-diff@2.0.0, latest-version@1.0.1, configstore@0.3.2)

sinon@1.15.4 node_modules/sinon
├── formatio@1.1.1
├── samsam@1.1.2
├── lolex@1.1.0
└── util@0.10.3 (inherits@2.0.1)

alt@0.17.1 node_modules/alt
├── transmitter@1.0.2
└── flux@2.0.3

lodash@3.10.0 node_modules/lodash

webpack-dev-server@1.10.1 node_modules/webpack-dev-server
├── supports-color@1.3.1
├── connect-history-api-fallback@1.1.0
├── strip-ansi@2.0.1 (ansi-regex@1.1.1)
├── webpack-dev-middleware@1.2.0 (memory-fs@0.2.0, mime@1.3.4)
├── http-proxy@1.11.1 (eventemitter3@1.1.1, requires-port@0.0.1)
├── stream-cache@0.0.2
├── optimist@0.6.1 (wordwrap@0.0.3, minimist@0.0.10)
├── serve-index@1.7.2 (escape-html@1.0.2, parseurl@1.3.0, batch@0.5.2, http-errors@1.3.1, accepts@1.2.12, debug@2.2.0, mime-types@2.1.4)
├── socket.io@1.3.6 (debug@2.1.0, has-binary-data@0.1.3, socket.io-adapter@0.3.1, engine.io@1.5.2, socket.io-parser@2.2.4)
└── socket.io-client@1.3.6 (to-array@0.1.3, indexof@0.0.1, component-bind@1.0.0, debug@0.7.4, backo2@1.0.2, object-component@0.0.3, component-emitter@1.1.2, has-binary@0.1.6, parseuri@0.0.2, engine.io-client@1.5.2, socket.io-parser@2.2.4)

node-libs-browser@0.5.2 node_modules/node-libs-browser
├── https-browserify@0.0.0
├── tty-browserify@0.0.0
├── constants-browserify@0.0.1
├── path-browserify@0.0.0
├── os-browserify@0.1.2
├── string_decoder@0.10.31
├── process@0.11.1
├── punycode@1.3.2
├── domain-browser@1.1.4
├── querystring-es3@0.2.1
├── assert@1.3.0
├── timers-browserify@1.4.1
├── stream-browserify@1.0.0 (inherits@2.0.1)
├── events@1.0.2
├── util@0.10.3 (inherits@2.0.1)
├── vm-browserify@0.0.4 (indexof@0.0.1)
├── console-browserify@1.1.0 (date-now@0.1.4)
├── http-browserify@1.7.0 (inherits@2.0.1, Base64@0.2.1)
├── readable-stream@1.1.13 (isarray@0.0.1, inherits@2.0.1, core-util-is@1.0.1)
├── url@0.10.3 (querystring@0.2.0)
├── buffer@3.3.1 (ieee754@1.1.6, is-array@1.0.1, base64-js@0.0.8)
├── browserify-zlib@0.1.4 (pako@0.2.7)
└── crypto-browserify@3.2.8 (ripemd160@0.2.0, pbkdf2-compat@2.0.1, sha.js@2.2.6)

webpack@1.10.5 node_modules/webpack
├── interpret@0.6.5
├── tapable@0.1.9
├── clone@1.0.2
├── memory-fs@0.2.0
├── async@1.4.0
├── supports-color@3.1.0 (has-flag@1.0.0)
├── enhanced-resolve@0.9.0 (graceful-fs@3.0.8)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── optimist@0.6.1 (wordwrap@0.0.3, minimist@0.0.10)
├── webpack-core@0.6.6 (source-list-map@0.1.5, source-map@0.4.4)
├── uglify-js@2.4.24 (uglify-to-browserify@1.0.2, async@0.2.10, yargs@3.5.4, source-map@0.1.34)
├── esprima@1.2.5
└── watchpack@0.2.8 (graceful-fs@3.0.8, async@0.9.2, chokidar@1.0.5)

moment@2.10.6 node_modules/moment

react@0.13.3 node_modules/react
└── envify@3.4.0 (through@2.3.8, jstransform@10.1.0)

node-sass@3.2.0 node_modules/node-sass
├── get-stdin@4.0.1
├── async-foreach@0.1.3
├── chalk@1.1.0 (escape-string-regexp@1.0.3, supports-color@2.0.0, ansi-styles@2.1.0, strip-ansi@3.0.0, has-ansi@2.0.0)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── meow@3.3.0 (object-assign@3.0.0, minimist@1.1.2, camelcase-keys@1.0.0, indent-string@1.2.2)
├── glob@5.0.14 (path-is-absolute@1.0.0, inherits@2.0.1, inflight@1.0.4, once@1.3.2, minimatch@2.0.10)
├── npmconf@2.1.2 (uid-number@0.0.5, ini@1.3.4, inherits@2.0.1, once@1.3.2, osenv@0.1.3, nopt@3.0.3, config-chain@1.1.9, semver@4.3.6)
├── nan@1.9.0
├── gaze@0.5.1 (globule@0.1.0)
├── sass-graph@2.0.0 (yargs@3.16.1)
├── request@2.60.0 (aws-sign2@0.5.0, forever-agent@0.6.1, stringstream@0.0.4, caseless@0.11.0, tunnel-agent@0.4.1, oauth-sign@0.8.0, isstream@0.1.2, json-stringify-safe@5.0.1, extend@3.0.0, node-uuid@1.4.3, qs@4.0.0, combined-stream@1.0.5, form-data@1.0.0-rc3, mime-types@2.1.4, http-signature@0.11.0, bl@1.0.0, tough-cookie@2.0.0, hawk@3.1.0, har-validator@1.8.0)
└── pangyp@2.2.1 (which@1.0.9, rimraf@2.2.8, graceful-fs@3.0.8, osenv@0.1.3, nopt@3.0.3, glob@4.3.5, fstream@1.0.7, semver@4.3.6, minimatch@2.0.10, tar@1.0.3, npmlog@1.0.0, request@2.51.0)

mongoose@4.1.0 node_modules/mongoose
├── regexp-clone@0.0.1
├── sliced@0.0.5
├── muri@1.0.0
├── hooks-fixed@1.1.0
├── mpromise@0.5.4
├── kareem@1.0.1
├── mpath@0.1.1
├── async@0.9.0
├── ms@0.1.0
├── mquery@1.6.1 (debug@2.2.0, bluebird@2.9.26)
├── mongodb@2.0.34 (readable-stream@1.0.31, mongodb-core@1.2.0)
└── bson@0.3.2 (bson-ext@0.1.10)

autoprefixer-loader@2.0.0 node_modules/autoprefixer-loader
├── postcss@4.1.16 (js-base64@2.1.9, source-map@0.4.4)
├── loader-utils@0.2.11 (big.js@3.1.3, json5@0.4.0)
└── autoprefixer-core@5.2.1 (num2fraction@1.1.0, browserslist@0.4.0, caniuse-db@1.0.30000251)

eslint@0.24.1 node_modules/eslint
├── escape-string-regexp@1.0.3
├── path-is-absolute@1.0.0
├── object-assign@2.1.1
├── xml-escape@1.0.0
├── user-home@1.1.1
├── strip-json-comments@1.0.3
├── estraverse-fb@1.3.1
├── globals@8.3.0
├── estraverse@4.1.0
├── text-table@0.2.0
├── debug@2.2.0 (ms@0.7.1)
├── chalk@1.1.0 (supports-color@2.0.0, ansi-styles@2.1.0, strip-ansi@3.0.0, has-ansi@2.0.0)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── optionator@0.5.0 (type-check@0.3.1, deep-is@0.1.3, levn@0.2.5, wordwrap@0.0.3, prelude-ls@1.1.2, fast-levenshtein@1.0.6)
├── minimatch@2.0.10 (brace-expansion@1.1.0)
├── espree@2.2.3
├── concat-stream@1.5.0 (inherits@2.0.1, typedarray@0.0.6, readable-stream@2.0.2)
├── is-my-json-valid@2.12.1 (jsonpointer@1.1.0, generate-function@2.0.0, xtend@4.0.0, generate-object-property@1.2.0)
├── doctrine@0.6.4 (isarray@0.0.1, esutils@1.1.6)
├── js-yaml@3.3.1 (esprima@2.2.0, argparse@1.0.2)
├── escope@3.2.0 (esrecurse@3.1.1, estraverse@3.1.0, es6-weak-map@0.1.4, es6-map@0.1.1)
└── inquirer@0.8.5 (figures@1.3.5, ansi-regex@1.1.1, cli-width@1.0.1, through@2.3.8, readline2@0.1.1, rx@2.5.3)

babel-istanbul@0.2.10 node_modules/babel-istanbul
├── supports-color@1.3.1
├── which@1.0.9
├── abbrev@1.0.7
├── wordwrap@0.0.3
├── nopt@3.0.3
├── once@1.3.2 (wrappy@1.0.1)
├── async@1.4.0
├── mkdirp@0.5.1 (minimist@0.0.8)
├── esprima@2.4.1
├── source-map@0.4.4 (amdefine@1.0.0)
├── resolve@1.1.6
├── fileset@0.2.1 (glob@5.0.14, minimatch@2.0.10)
├── js-yaml@3.3.1 (esprima@2.2.0, argparse@1.0.2)
├── escodegen@1.6.1 (esutils@1.1.6, estraverse@1.9.3, optionator@0.5.0, source-map@0.1.43, esprima@1.2.5)
├── handlebars@3.0.0 (optimist@0.6.1, source-map@0.1.43, uglify-js@2.3.6)
├── babel-runtime@5.6.20 (core-js@0.9.18)
└── babel-core@5.6.20 (slash@1.0.0, babel-plugin-remove-console@1.0.1, babel-plugin-remove-debugger@1.0.1, babel-plugin-property-literals@1.0.1, babel-plugin-inline-environment-variables@1.0.1, babel-plugin-jscript@1.0.4, babel-plugin-eval@1.0.1, babel-plugin-member-expression-literals@1.0.1, babel-plugin-undefined-to-void@1.1.6, babel-plugin-react-constant-elements@1.0.3, to-fast-properties@1.0.1, shebang-regex@1.0.0, trim-right@1.0.1, babel-plugin-react-display-name@1.0.3, path-is-absolute@1.0.0, path-exists@1.0.0, babel-plugin-constant-folding@1.0.1, fs-readdir-recursive@0.1.2, babel-plugin-proto-to-assign@1.0.4, babel-plugin-dead-code-elimination@1.0.2, babel-plugin-runtime@1.0.7, strip-json-comments@1.0.3, private@0.1.6, globals@6.4.1, estraverse@4.1.0, esutils@2.0.2, convert-source-map@1.1.1, home-or-tmp@1.0.0, babel-plugin-undeclared-variables-check@1.0.2, line-numbers@0.2.0, js-tokens@1.0.1, debug@2.2.0, repeating@1.1.3, output-file-sync@1.1.1, detect-indent@3.0.1, chalk@1.1.0, minimatch@2.0.10, is-integer@1.0.4, source-map-support@0.2.10, acorn-jsx@1.0.3, regexpu@1.2.0, regenerator@0.8.34, core-js@0.9.18)

babel-eslint@3.1.30 node_modules/babel-eslint
├── lodash.assign@3.2.0 (lodash._baseassign@3.2.0, lodash._createassigner@3.1.1, lodash.keys@3.1.2)
├── lodash.pick@3.1.0 (lodash._bindcallback@3.0.1, lodash._pickbyarray@3.0.2, lodash.restparam@3.6.1, lodash._baseflatten@3.1.4, lodash._pickbycallback@3.0.0)
└── babel-core@5.8.20 (slash@1.0.0, try-resolve@1.0.1, babel-plugin-remove-debugger@1.0.1, babel-plugin-remove-console@1.0.1, babel-plugin-property-literals@1.0.1, babel-plugin-inline-environment-variables@1.0.1, babel-plugin-jscript@1.0.4, babel-plugin-eval@1.0.1, babel-plugin-undefined-to-void@1.1.6, babel-plugin-member-expression-literals@1.0.1, babel-plugin-react-constant-elements@1.0.3, to-fast-properties@1.0.1, trim-right@1.0.1, shebang-regex@1.0.0, path-exists@1.0.0, babel-plugin-react-display-name@1.0.3, path-is-absolute@1.0.0, babel-plugin-constant-folding@1.0.1, fs-readdir-recursive@0.1.2, babel-plugin-proto-to-assign@1.0.4, babel-plugin-dead-code-elimination@1.0.2, babel-plugin-runtime@1.0.7, private@0.1.6, globals@6.4.1, esutils@2.0.2, convert-source-map@1.1.1, home-or-tmp@1.0.0, babel-plugin-undeclared-variables-check@1.0.2, line-numbers@0.2.0, js-tokens@1.0.1, chalk@1.1.0, debug@2.2.0, repeating@1.1.3, detect-indent@3.0.1, babylon@5.8.20, output-file-sync@1.1.1, source-map@0.4.4, minimatch@2.0.10, resolve@1.1.6, is-integer@1.0.4, bluebird@2.9.34, json5@0.4.0, source-map-support@0.2.10, regexpu@1.2.0, regenerator@0.8.35, core-js@1.0.1)

babel@5.8.20 node_modules/babel
├── slash@1.0.0
├── path-is-absolute@1.0.0
├── path-exists@1.0.0
├── fs-readdir-recursive@0.1.2
├── convert-source-map@1.1.1
├── commander@2.8.1 (graceful-readlink@1.0.1)
├── source-map@0.4.4 (amdefine@1.0.0)
├── output-file-sync@1.1.1 (xtend@4.0.0, mkdirp@0.5.1)
├── glob@5.0.14 (inherits@2.0.1, once@1.3.2, inflight@1.0.4, minimatch@2.0.10)
├── chokidar@1.0.5 (arrify@1.0.0, is-glob@1.1.3, glob-parent@1.2.0, async-each@0.1.6, is-binary-path@1.0.1, readdirp@1.4.0, anymatch@1.3.0, fsevents@0.3.7)
└── babel-core@5.8.20 (try-resolve@1.0.1, babel-plugin-remove-debugger@1.0.1, babel-plugin-remove-console@1.0.1, babel-plugin-eval@1.0.1, babel-plugin-property-literals@1.0.1, babel-plugin-jscript@1.0.4, babel-plugin-inline-environment-variables@1.0.1, babel-plugin-react-constant-elements@1.0.3, babel-plugin-member-expression-literals@1.0.1, babel-plugin-undefined-to-void@1.1.6, trim-right@1.0.1, to-fast-properties@1.0.1, shebang-regex@1.0.0, babel-plugin-react-display-name@1.0.3, babel-plugin-constant-folding@1.0.1, babel-plugin-proto-to-assign@1.0.4, babel-plugin-dead-code-elimination@1.0.2, babel-plugin-runtime@1.0.7, private@0.1.6, globals@6.4.1, esutils@2.0.2, home-or-tmp@1.0.0, babel-plugin-undeclared-variables-check@1.0.2, line-numbers@0.2.0, js-tokens@1.0.1, chalk@1.1.0, debug@2.2.0, repeating@1.1.3, detect-indent@3.0.1, babylon@5.8.20, minimatch@2.0.10, resolve@1.1.6, is-integer@1.0.4, bluebird@2.9.34, json5@0.4.0, source-map-support@0.2.10, regexpu@1.2.0, regenerator@0.8.35, core-js@1.0.1)

babel-core@5.8.20 node_modules/babel-core
├── try-resolve@1.0.1
├── slash@1.0.0
├── babel-plugin-remove-console@1.0.1
├── babel-plugin-remove-debugger@1.0.1
├── babel-plugin-property-literals@1.0.1
├── babel-plugin-eval@1.0.1
├── babel-plugin-jscript@1.0.4
├── babel-plugin-inline-environment-variables@1.0.1
├── babel-plugin-member-expression-literals@1.0.1
├── babel-plugin-react-constant-elements@1.0.3
├── babel-plugin-undefined-to-void@1.1.6
├── shebang-regex@1.0.0
├── trim-right@1.0.1
├── to-fast-properties@1.0.1
├── babel-plugin-react-display-name@1.0.3
├── path-is-absolute@1.0.0
├── path-exists@1.0.0
├── babel-plugin-constant-folding@1.0.1
├── fs-readdir-recursive@0.1.2
├── babel-plugin-proto-to-assign@1.0.4
├── babel-plugin-dead-code-elimination@1.0.2
├── babel-plugin-runtime@1.0.7
├── private@0.1.6
├── globals@6.4.1
├── esutils@2.0.2
├── convert-source-map@1.1.1
├── home-or-tmp@1.0.0 (os-tmpdir@1.0.1, user-home@1.1.1)
├── babel-plugin-undeclared-variables-check@1.0.2 (leven@1.0.2)
├── js-tokens@1.0.1
├── line-numbers@0.2.0 (left-pad@0.0.3)
├── debug@2.2.0 (ms@0.7.1)
├── repeating@1.1.3 (is-finite@1.0.1)
├── detect-indent@3.0.1 (get-stdin@4.0.1, minimist@1.1.2)
├── chalk@1.1.0 (escape-string-regexp@1.0.3, supports-color@2.0.0, ansi-styles@2.1.0, strip-ansi@3.0.0, has-ansi@2.0.0)
├── babylon@5.8.20
├── output-file-sync@1.1.1 (xtend@4.0.0, mkdirp@0.5.1)
├── source-map@0.4.4 (amdefine@1.0.0)
├── resolve@1.1.6
├── minimatch@2.0.10 (brace-expansion@1.1.0)
├── is-integer@1.0.4 (is-finite@1.0.1, is-nan@1.1.0)
├── bluebird@2.9.34
├── source-map-support@0.2.10 (source-map@0.1.32)
├── json5@0.4.0
├── regexpu@1.2.0 (regjsgen@0.2.0, regenerate@1.2.1, regjsparser@0.1.4, recast@0.10.26)
├── regenerator@0.8.35 (through@2.3.8, recast@0.10.24, commoner@0.10.3, esprima-fb@15001.1.0-dev-harmony-fb, defs@1.1.0)
└── core-js@1.0.1

babel-loader@5.3.2 node_modules/babel-loader
├── object-assign@3.0.0
├── loader-utils@0.2.11 (big.js@3.1.3, json5@0.4.0)
└── babel-core@5.8.20 (slash@1.0.0, try-resolve@1.0.1, babel-plugin-remove-debugger@1.0.1, babel-plugin-remove-console@1.0.1, babel-plugin-property-literals@1.0.1, babel-plugin-inline-environment-variables@1.0.1, babel-plugin-eval@1.0.1, babel-plugin-jscript@1.0.4, babel-plugin-react-constant-elements@1.0.3, babel-plugin-member-expression-literals@1.0.1, babel-plugin-undefined-to-void@1.1.6, shebang-regex@1.0.0, to-fast-properties@1.0.1, trim-right@1.0.1, babel-plugin-react-display-name@1.0.3, path-exists@1.0.0, path-is-absolute@1.0.0, babel-plugin-constant-folding@1.0.1, fs-readdir-recursive@0.1.2, babel-plugin-proto-to-assign@1.0.4, babel-plugin-dead-code-elimination@1.0.2, babel-plugin-runtime@1.0.7, private@0.1.6, globals@6.4.1, esutils@2.0.2, convert-source-map@1.1.1, home-or-tmp@1.0.0, babel-plugin-undeclared-variables-check@1.0.2, line-numbers@0.2.0, js-tokens@1.0.1, chalk@1.1.0, debug@2.2.0, repeating@1.1.3, detect-indent@3.0.1, babylon@5.8.20, output-file-sync@1.1.1, source-map@0.4.4, minimatch@2.0.10, resolve@1.1.6, is-integer@1.0.4, bluebird@2.9.34, json5@0.4.0, source-map-support@0.2.10, regexpu@1.2.0, regenerator@0.8.35, core-js@1.0.1)

node-xmpp-client@1.0.0-alpha23 node_modules/node-xmpp-client
├── browser-request@0.3.3
├── minimist@0.0.8
├── debug@1.0.4 (ms@0.6.2)
├── faye-websocket@0.7.3 (websocket-driver@0.6.2)
├── request@2.55.0 (caseless@0.9.0, aws-sign2@0.5.0, forever-agent@0.6.1, stringstream@0.0.4, oauth-sign@0.6.0, tunnel-agent@0.4.1, isstream@0.1.2, json-stringify-safe@5.0.1, node-uuid@1.4.3, qs@2.4.2, combined-stream@0.0.7, form-data@0.2.0, mime-types@2.0.14, http-signature@0.10.1, bl@0.9.4, tough-cookie@2.0.0, hawk@2.3.1, har-validator@1.8.0)
└── node-xmpp-core@1.0.0-alpha14 (tls-connect@0.2.2, debug@2.2.0, reconnect-core@0.0.1, node-stringprep@0.7.2, ltx@0.9.1)
```

Найти сообщение про конфигурирование здесь достаточно сложно ;) Поэтому есть вариант запускать `make`, который спрячет ненужный вывод `npm` ( сейчас даже с `--silent` много грязи ), а потом покажет дополнительное сообщение про конфигурирование.
