### PR TITLE
Add order to sections in pull request body

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-loader": "^5.3.2",
     "chai": "^3.2.0",
     "css-loader": "0.17.0",
+    "cz-conventional-changelog": "^1.1.4",
     "eslint": "^1.3.1",
     "eslint-plugin-react": "^3.3.1",
     "extract-text-webpack-plugin": "^0.8.2",
@@ -77,5 +78,8 @@
     "style-loader": "^0.12.3",
     "webpack": "^1.12.1",
     "webpack-dev-server": "^1.10.1"
+  },
+  "czConfig": {
+    "path": "./node_modules/cz-conventional-changelog"
   }
 }

--- a/services/pull-request-github/__tests__/index.js
+++ b/services/pull-request-github/__tests__/index.js
@@ -2,11 +2,11 @@
 
 import { PullRequestGitHub } from '../../pull-request-github';
 
-describe('services/pull-request-github', function () {
+describe('services/pull-request-github', () => {
 
   let github, model, options;
 
-  beforeEach(function () {
+  beforeEach(() => {
     model = sinon.stub();
     github = sinon.stub();
     options = {
@@ -17,7 +17,7 @@ describe('services/pull-request-github', function () {
     };
   });
 
-  it('should be able to clean pull request body from old content', function () {
+  it('should be able to clean pull request body from old content', () => {
     const gpr = new PullRequestGitHub(model, github, options);
     const body = `
 BODY TEXT
@@ -31,7 +31,7 @@ EXTRA BODY TEXT
     assert.equal(result, 'BODY TEXT');
   });
 
-  it('should be able to replace pull request body', function () {
+  it('should be able to replace pull request body', () => {
     const gpr = new PullRequestGitHub(model, github, options);
     const body = `
 BODY TEXT
@@ -57,6 +57,26 @@ BODY TEXT
                      '<div id="bottom"></div>';
 
     assert.equal(pullRequest.body, expected);
+  });
+
+  describe('#buildBodyContent', () => {
+    const sections = {
+      id1: 'content 1',
+      id2: {
+        pos: 1,
+        content: 'content 2'
+      },
+      id3: {
+        pos: 10,
+        content: 'content 3'
+      }
+    };
+
+    it('should put sections in correct order in body content', () => {
+      const gpr = new PullRequestGitHub(model, github, options);
+
+      assert.equal(gpr.buildBodyContent(sections), '<div>content 2</div><div>content 3</div><div>content 1</div>');
+    });
   });
 
 });

--- a/services/review-badges.js
+++ b/services/review-badges.js
@@ -151,7 +151,8 @@ export default function (options, imports) {
     github.setBodySection(
       payload.pullRequest.id,
       'review:badge',
-      badgeContent
+      badgeContent,
+      100 // position
     );
   }
 


### PR DESCRIPTION
Now any section can have it's own position and will be sorted by it before putting into pull request
description on github.
#66
